### PR TITLE
Fix dashboard history duplication

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -45,6 +45,16 @@
 </div>
 
 <script>
+function updateTable(sel, rows, opts={}){
+  if ($.fn.dataTable.isDataTable(sel)) {
+    const t = $(sel).DataTable();
+    t.clear();
+    t.rows.add(rows);
+    t.draw();
+  } else {
+    $(sel).DataTable(Object.assign({data:rows}, opts));
+  }
+}
 function loadTables(){
 
       // ---- Balance EUR + beneficio ----
@@ -66,8 +76,7 @@ function loadTables(){
       s.entry.toFixed(2),
       s.unreal.toFixed(2)
     ]);
-    $('#tblState').DataTable({data:rows, destroy:true,
-                              searching:false, paging:false});
+    updateTable('#tblState', rows, {searching:false, paging:false});
   });
 
 
@@ -76,21 +85,25 @@ fetch('/api/history').then(r=>r.json()).then(data=>{
   const rows = data.map(x=>[
     x.datetime,
     x.pair,
-    x.side,                   // ahora usamos la propiedad 'side' (buy/sell)
-    (+x.price).toFixed(2)     // y 'price' en lugar de 'Close'
+    x.side,
+    (+x.price).toFixed(2)
   ]);
-
-  $('#tblHist').DataTable({data:rows, destroy:true, pageLength:10});
+  updateTable('#tblHist', rows, {pageLength:10});
 });
 
 
   // Logs
   fetch('/api/logs').then(r=>r.json()).then(data=>{
     const rows = data.map(x=>[
-      x.datetime, x.pair,
-      (+x.Close).toFixed(2), x.RSI, x.SMA, x.decision, x.motivo
+      x.datetime,
+      x.pair,
+      (+x.Close).toFixed(2),
+      x.RSI,
+      x.SMA,
+      x.decision,
+      x.motivo
     ]);
-    $('#tblLogs').DataTable({data:rows, destroy:true, pageLength:25});
+    updateTable('#tblLogs', rows, {pageLength:25});
   });
 }
 loadTables();


### PR DESCRIPTION
## Summary
- avoid duplicated table rows when dashboard refreshes

## Testing
- `python -m py_compile app.py bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68583cca345c8326a10e0f6c290f4729