### PR TITLE
Remove obsolete clear buttons

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,8 +17,6 @@ app.secret_key = os.getenv("FLASK_SECRET", "change-me")
 login_manager = LoginManager(app)
 login_manager.login_view = "login"
 
-# Cabecera usada si se desea limpiar historial_trades.csv
-HEAD_TRADE = ["datetime", "pair", "Close", "RSI", "SMA", "decision"]
 
 class User(UserMixin):
     id = 1  # single-user
@@ -124,31 +122,6 @@ def api_history():
     # Ordena por fecha descendente y limita (p.ej.) a los últimos 500
     trades.sort(key=lambda x: x['datetime'], reverse=True)
     return jsonify(trades[:500])
-@app.route("/api/clear_logs", methods=["POST"])
-@login_required
-def api_clear_logs():
-    path = "log_evaluaciones.csv"
-
-    # Sobrescribe el fichero con solo la cabecera
-    with open(path, "w", newline="", encoding="utf-8") as f:
-        import csv
-        csv.writer(f).writerow(bot.HEAD_LOG)          # usa encabezado del bot
-
-    # Limpia también el registro en memoria (opcional)
-    if hasattr(bot, "log_records"):
-        bot.log_records.clear()
-
-    return jsonify({"ok": True})
-
-@app.route("/api/clear_history", methods=["POST"])
-@login_required
-def api_clear_history():
-    path = "historial_trades.csv"
-    with open(path, "w", newline="", encoding="utf-8") as f:
-        import csv
-        csv.writer(f).writerow(HEAD_TRADE)
-    # Opcional: limpiar estructura en memoria, si la usas
-    return jsonify({"ok": True})
 
 # ---------- Callback del bot ----------
 def notify_clients():

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -17,11 +17,7 @@
     </table>
 </div>
 
-  <h3 class="mt-4">Historial de operaciones
-     <button id="btnClearHistory" class="btn btn-sm btn-danger">
-    Vaciar historial
-  </button>
-  </h3>
+  <h3 class="mt-4">Historial de operaciones</h3>
   <div class="responsive-table">
     <table id="tblHist" class="table table-sm table-bordered w-100">
       <thead><tr>
@@ -30,11 +26,7 @@
     </table>
   </div>
 
-  <h3 class="mt-4">Logs de evaluaciones
-      <button id="btnClear" class="btn btn-sm btn-danger">
-    Vaciar logs
-  </button>
-  </h3>
+  <h3 class="mt-4">Logs de evaluaciones</h3>
   <div class="responsive-table">
     <table id="tblLogs" class="table table-sm table-bordered w-100">
       <thead><tr>
@@ -93,37 +85,8 @@ fetch('/api/history').then(r=>r.json()).then(data=>{
     $('#tblLogs').DataTable({data:rows, destroy:true, pageLength:25});
   });
 }
+
 loadTables();
-document.getElementById('btnClear').addEventListener('click', () => {
-  if (!confirm('¿Seguro que quieres borrar todos los logs?')) return;
-
-  fetch('/api/clear_logs', { method: 'POST' })
-    .then(r => r.json())
-    .then(j => {
-      if (j.ok) {
-        alert('Logs vaciados');
-        loadTables();            // recarga tablas para reflejar cambio
-      } else {
-        alert('No se pudieron borrar');
-      }
-    })
-    .catch(err => alert(err));
-});
-document.getElementById('btnClearHistory').addEventListener('click', () => {
-  if (!confirm('¿Seguro que quieres borrar todo el historial de operaciones?')) return;
-
-  fetch('/api/clear_history', { method: 'POST' })
-    .then(r => r.json())
-    .then(j => {
-      if (j.ok) {
-        alert('Historial vaciado');
-        loadTables();            // recarga tablas para reflejar cambio
-      } else {
-        alert('No se pudo borrar el historial');
-      }
-    })
-    .catch(err => alert(err));
-});
 
 
 setInterval(loadTables, 60000); // refresca cada minuto


### PR DESCRIPTION
## Summary
- remove clear-history and clear-logs buttons from dashboard
- drop related API endpoints

## Testing
- `python -m py_compile app.py bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68583d53ede083269cdd9e12d92707ba