### PR TITLE
Fix duplicate trades in history API

### DIFF
--- a/app.py
+++ b/app.py
@@ -115,8 +115,13 @@ def api_history():
 
     # Aplana la lista y formatea cada trade
     trades = []
+    seen = set()  # evita duplicados si el exchange devuelve el mismo trade
     for trades_list in all_results:
         for t in trades_list:
+            uid = f"{t.get('id')}-{t['symbol']}"
+            if uid in seen:
+                continue
+            seen.add(uid)
             trades.append({
                 "datetime": datetime.fromtimestamp(t['timestamp'] / 1000).isoformat(),
                 "pair":     t['symbol'],


### PR DESCRIPTION
## Summary
- deduplicate trades when building the history list

## Testing
- `python -m py_compile app.py bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6858417ca1a4832690176720473045c9