### PR TITLE
Add amount column to trade history

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -21,7 +21,11 @@
   <div class="responsive-table">
     <table id="tblHist" class="table table-sm table-bordered w-100">
       <thead><tr>
-        <th>Fecha</th><th>Par</th><th>Tipo</th><th>Precio</th>
+        <th>Fecha</th>
+        <th>Par</th>
+        <th>Tipo</th>
+        <th>Precio</th>
+        <th>Cantidad</th>
       </tr></thead>
     </table>
   </div>
@@ -78,7 +82,8 @@ fetch('/api/history').then(r=>r.json()).then(data=>{
     x.datetime,
     x.pair,
     x.side,
-    (+x.price).toFixed(2)
+    (+x.price).toFixed(2),
+    x.amount.toFixed(6)
   ]);
   updateTable('#tblHist', rows, {pageLength:10});
 });


### PR DESCRIPTION
## Summary
- display trade amount in history table

## Testing
- `python -m py_compile app.py bot.py`

------
https://chatgpt.com/codex/tasks/task_e_685847208c9c832684eed9e8a150801a