### PR TITLE
Add log DB size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Pequeño bot de trading con interfaz web basada en Flask. Registra las evaluacio
    FLASK_SECRET=una-clave-secreta
    WEB_USER=admin
    WEB_PASS_HASH=<hash bcrypt de la contraseña>
+   # Tamaño máximo de logs.db en MB (opcional)
+   LOG_DB_MAX_MB=5
    ```
    - `TRADE_FRACTION` indica la fracción del capital libre que se usará en cada operación.
    - `RSI_LOW` y `RSI_HIGH` permiten ajustar los umbrales de sobreventa y sobrecompra.


### PR DESCRIPTION
## Summary
- allow configuring a maximum size for `logs.db`
- prune old log records when the limit is exceeded
- document new `LOG_DB_MAX_MB` environment variable

## Testing
- `python -m py_compile app.py bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68599ecaf490832683293f23a950c2db