### PR TITLE
Calculate profit from trade history

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ python app.py
 Accede a `http://localhost:8000` e inicia sesión con las credenciales configuradas.
 
 Para producción se recomienda usar el `Dockerfile` incluido o un servidor WSGI como Gunicorn.
+
+La ruta `/api/balance` calcula el beneficio total a partir del historial de operaciones
+obtenido de Binance. Así, el valor reflejado en el panel se mantiene actualizado
+incluso tras reiniciar la aplicación.

--- a/app.py
+++ b/app.py
@@ -28,10 +28,12 @@ class User(UserMixin):
 @app.route("/api/balance")
 @login_required
 def api_balance():
-    # accedemos a capital_free y benefit_total que mantiene bot.py
+    bal = bot.binance.fetch_balance()["free"]
+    free = float(bal.get(bot.BASE_CURRENCY, 0))
+    benefit = bot.calculate_total_profit()
     return jsonify({
-        "free": bot.capital_free,
-        "benefit": bot.benefit_total
+        "free": free,
+        "benefit": benefit
     })
 
 


### PR DESCRIPTION
## Summary
- compute realized profit directly from Binance trade history
- refresh `/api/balance` using current balance and calculated profit
- document the new behaviour in README

## Testing
- `python -m py_compile app.py bot.py`


------
https://chatgpt.com/codex/tasks/task_e_685a62d5c3208326b018989d1cf263b3