### PR TITLE
Add daily profit chart to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ python app.py
 ```
 Accede a `http://localhost:8000` e inicia sesión con las credenciales configuradas.
 
+El panel ahora incluye una gráfica con el beneficio diario que se alimenta de
+la ruta `/api/profit_series`.
+
 Para producción se recomienda usar el `Dockerfile` incluido o un servidor WSGI como Gunicorn.
 
 La ruta `/api/balance` calcula el beneficio total a partir del historial de operaciones

--- a/app.py
+++ b/app.py
@@ -36,6 +36,12 @@ def api_balance():
         "benefit": benefit
     })
 
+@app.route("/api/profit_series")
+@login_required
+def api_profit_series():
+    """Devuelve beneficio diario para la gráfica del dashboard."""
+    return jsonify(bot.calculate_profit_series())
+
 
 @login_manager.user_loader
 def load_user(user_id):

--- a/templates/base.html
+++ b/templates/base.html
@@ -36,5 +36,6 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
   <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </body>
 </html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -38,6 +38,9 @@
       </tr></thead>
     </table>
   </div>
+  <h3 class="mt-4">Beneficio diario</h3>
+  <canvas id="profitChart" class="w-100" height="120"></canvas>
+
 </div>
 
 <script>
@@ -101,6 +104,24 @@ fetch('/api/history').then(r=>r.json()).then(data=>{
       x.motivo
     ]);
     updateTable('#tblLogs', rows, {pageLength:25});
+  });
+
+  // ---- Beneficio diario ----
+  fetch('/api/profit_series').then(r=>r.json()).then(data=>{
+    const labels = data.map(x=>x.date);
+    const vals = data.map(x=>x.profit.toFixed(2));
+    if(window.profitChart){
+      profitChart.data.labels = labels;
+      profitChart.data.datasets[0].data = vals;
+      profitChart.update();
+    } else {
+      const ctx = document.getElementById('profitChart');
+      window.profitChart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: labels, datasets: [{ label: 'Beneficio', data: vals, borderColor: 'green', fill:false, tension:0.3 }]},
+        options: { scales: { y: { beginAtZero:true }}}
+      });
+    }
   });
 }
   loadTables();


### PR DESCRIPTION
## Summary
- compute profit aggregated by day
- expose new endpoint `/api/profit_series`
- add Chart.js and canvas for showing daily profit
- update README with new route information

## Testing
- `python -m py_compile app.py bot.py`


------
https://chatgpt.com/codex/tasks/task_e_685db4fae5b48326ae1cace19eba1e5d