### PR TITLE
Fix dashboard chart initialization

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -124,7 +124,10 @@ fetch('/api/history').then(r=>r.json()).then(data=>{
     }
   });
 }
+
+window.addEventListener('load', () => {
   loadTables();
-setInterval(loadTables, 60000); // refresca cada minuto
+  setInterval(loadTables, 60000); // refresca cada minuto
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- wait for external scripts to load before starting the dashboard

## Testing
- `python -m py_compile app.py bot.py`

------
https://chatgpt.com/codex/tasks/task_e_685e693c0824832687b73453b9956c3f